### PR TITLE
Add yamllint pre-commit hook

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "pre-commit-hooks"]
 	path = submodule_pre_commit_hooks
 	url = git@github.com:pre-commit/pre-commit-hooks.git
-[submodule "submodule_yamllint"]
-	path = submodule_yamllint
-	url = https://github.com/adrienverge/yamllint.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "pre-commit-hooks"]
 	path = submodule_pre_commit_hooks
 	url = git@github.com:pre-commit/pre-commit-hooks.git
+[submodule "submodule_yamllint"]
+	path = submodule_yamllint
+	url = https://github.com/adrienverge/yamllint.git

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -51,3 +51,10 @@
   entry: requirements-txt-fixer
   language: python
   files: requirements.*\.txt$
+
+- id: yamllint
+  name: yamllint
+  description: This hook runs yamllint.
+  entry: yamllint
+  language: python
+  types: [file, yaml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,7 @@ description = ""
 authors = ["Your Name <you@example.com>"]
 include = [
   "pre_commit_hooks/*",
-  "submodule_pre_commit_hooks/pre_commit_hooks/*",
-  "submodule_yamllint/yamllint/*"
+  "submodule_pre_commit_hooks/pre_commit_hooks/*"
 ]
 
 [tool.poetry.scripts]
@@ -14,10 +13,10 @@ end-of-file-fixer="submodule_pre_commit_hooks.pre_commit_hooks.end_of_file_fixer
 trailing-whitespace-fixer="submodule_pre_commit_hooks.pre_commit_hooks.trailing_whitespace_fixer:main"
 pretty-format-json="submodule_pre_commit_hooks.pre_commit_hooks.pretty_format_json:main"
 requirements-txt-fixer="submodule_pre_commit_hooks.pre_commit_hooks.requirements_txt_fixer:main"
-yamllint="submodule_yamllint.yamllint.cli:run"
 
 [tool.poetry.dependencies]
 python = "^3.7"
+yamllint = "^v1.25.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ description = ""
 authors = ["Your Name <you@example.com>"]
 include = [
   "pre_commit_hooks/*",
-  "submodule_pre_commit_hooks/pre_commit_hooks/*"
+  "submodule_pre_commit_hooks/pre_commit_hooks/*",
+  "submodule_yamllint/yamllint/*"
 ]
 
 [tool.poetry.scripts]
@@ -13,6 +14,7 @@ end-of-file-fixer="submodule_pre_commit_hooks.pre_commit_hooks.end_of_file_fixer
 trailing-whitespace-fixer="submodule_pre_commit_hooks.pre_commit_hooks.trailing_whitespace_fixer:main"
 pretty-format-json="submodule_pre_commit_hooks.pre_commit_hooks.pretty_format_json:main"
 requirements-txt-fixer="submodule_pre_commit_hooks.pre_commit_hooks.requirements_txt_fixer:main"
+yamllint="submodule_yamllint.yamllint.cli:run"
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
Tested on https://github.com/lightspeed-hospitality/graphql-schema-registry/pull/4

It's a bit different from the rest because I just install yamllint from pypi as a dependency as opposed to submodules or using the same file as the original repo of yamllint.