### PR TITLE
Add shellcheck and shfmt hooks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "pre-commit-hooks"]
 	path = submodule_pre_commit_hooks
 	url = git@github.com:pre-commit/pre-commit-hooks.git
+[submodule "submodule_syntaqx_git_hooks"]
+	path = submodule_syntaqx_git_hooks
+	url = git@github.com:syntaqx/git-hooks.git

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -68,3 +68,21 @@
   language: python
   types: [file, yaml]
 
+- id: shellcheck
+  name: Test shell scripts with shellcheck
+  description: Shell scripts conform to shellcheck
+  entry: submodule_syntaqx_git_hooks/hooks/shellcheck.sh
+  language: script
+  types: [shell]
+  exclude_types: [csh, perl, python, ruby, tcsh, zsh]
+  args: [-e, SC1091]
+  additional_dependencies: [shellcheck]
+
+- id: shfmt
+  name: Check shell style with shfmt
+  language: script
+  entry: submodule_syntaqx_git_hooks/hooks/shfmt.sh
+  types: [shell]
+  exclude_types: [csh, perl, python, ruby, tcsh, zsh]
+  args: ['-l', '-i', '2', '-ci']
+  additional_dependencies: [shfmt]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -76,7 +76,6 @@
   types: [shell]
   exclude_types: [csh, perl, python, ruby, tcsh, zsh]
   args: [-e, SC1091]
-  additional_dependencies: [shellcheck]
 
 - id: shfmt
   name: Check shell style with shfmt
@@ -85,4 +84,3 @@
   types: [shell]
   exclude_types: [csh, perl, python, ruby, tcsh, zsh]
   args: ['-l', '-i', '2', '-ci']
-  additional_dependencies: [shfmt]

--- a/pre_commit_hooks/shfmt.sh
+++ b/pre_commit_hooks/shfmt.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Original: https://github.com/jumanjihouse/pre-commit-hooks#shfmt
+# Forked to change runtime to /usr/bin/env on win10
+set -eu
+
+readonly DEBUG=${DEBUG:-unset}
+if [ "${DEBUG}" != unset ]; then
+  set -x
+fi
+
+if ! command -v shfmt >/dev/null 2>&1; then
+  echo 'This check needs shfmt from https://github.com/mvdan/sh/releases'
+  exit 1
+fi
+
+readonly cmd=(shfmt "$@")
+echo "[RUN] ${cmd[@]}"
+output="$("${cmd[@]}" 2>&1)"
+readonly output
+
+if [ -n "${output}" ]; then
+  echo '[FAIL]'
+  echo
+  echo "${output}"
+  echo
+  echo 'The above files have style errors.'
+  echo 'Use "shfmt -d" option to show diff.'
+  echo 'Use "shfmt -w" option to write (autocorrect).'
+  exit 1
+else
+  echo '[PASS]'
+fi

--- a/pre_commit_hooks/shfmt.sh
+++ b/pre_commit_hooks/shfmt.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Original: https://github.com/syntaqx/git-hooks
+# Forked to auto-install shfmt and give better command suggestions
 # Original: https://github.com/jumanjihouse/pre-commit-hooks#shfmt
 # Forked to change runtime to /usr/bin/env on win10
 set -eu
@@ -9,7 +11,11 @@ if [ "${DEBUG}" != unset ]; then
 fi
 
 if ! command -v shfmt >/dev/null 2>&1; then
-  echo 'This check needs shfmt from https://github.com/mvdan/sh/releases'
+  if command -v brew &>/dev/null; then
+    brew install shfmt
+  else
+    >&2 echo 'This check needs shfmt from https://github.com/mvdan/sh/releases or brew install shfmt'
+  fi
   exit 1
 fi
 
@@ -24,8 +30,8 @@ if [ -n "${output}" ]; then
   echo "${output}"
   echo
   echo 'The above files have style errors.'
-  echo 'Use "shfmt -d" option to show diff.'
-  echo 'Use "shfmt -w" option to write (autocorrect).'
+  echo "Use 'shfmt -d $@' option to show diff."
+  echo "Use 'shfmt -w $@' option to write (autocorrect)."
   exit 1
 else
   echo '[PASS]'


### PR DESCRIPTION
Adding shellcheck pre-commit hooks and shfmt.

Note: I had to modify shfmt to make it easier to use (now it tries to auto-install shfmt using brew if it can - like the circleci hook)