### PR TITLE
circleci scripts: add path argument

### DIFF
--- a/pre_commit_hooks/circleci-config-pack.sh
+++ b/pre_commit_hooks/circleci-config-pack.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+_PATH=$1
+if [ -z "${_PATH}" ]; then
+  _PATH=.circleci/config.yml
+fi
+
 # do not run in Circle CI
 if [[ -n $CIRCLECI ]]; then
   echo "Only to be executed locally, as a pre-commit hook."
@@ -20,4 +25,4 @@ if ! command -v circleci &>/dev/null; then
   exit 1
 fi
 
-circleci --skip-update-check config pack .circleci/config > .circleci/config.yml
+circleci --skip-update-check config pack .circleci/config > "${_PATH}"

--- a/pre_commit_hooks/circleci-config-validate.sh
+++ b/pre_commit_hooks/circleci-config-validate.sh
@@ -4,6 +4,11 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+_PATH=$1
+if [ -z "${_PATH}" ]; then
+  _PATH=.circleci/config.yml
+fi
+
 DEBUG=${DEBUG:=0}
 [[ $DEBUG -eq 1 ]] && set -o xtrace
 
@@ -23,7 +28,7 @@ if ! command -v circleci &>/dev/null; then
   exit 1
 fi
 
-if ! eMSG=$(circleci --skip-update-check config validate -c .circleci/config.yml); then
+if ! eMSG=$(circleci --skip-update-check config validate -c "${_PATH}"); then
   echo "CircleCI Configuration Failed Validation."
   echo $eMSG
   exit 1


### PR DESCRIPTION
Adding possibility of generating and validating other than default circleci configs, example:

```
  - repo: git@github.com:lightspeed-hospitality/pre-commit-hooks.git
    rev: v0.5.0
    hooks:
      - id: circleci-config-pack
        args: ['.circleci/another_config.yml']
      - id: circleci-config-validate
        args: ['.circleci/another_config.yml']
```

If not passed it's still `.circleci/config.yml` by default.