### PR TITLE
Update formatter version to work with jdk16+

### DIFF
--- a/pre_commit_hooks/google-java-code-format.sh
+++ b/pre_commit_hooks/google-java-code-format.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-FORMATTER_VERSION=1.9
+FORMATTER_VERSION=1.13.0
 
 mkdir -p .cache
 pushd .cache > /dev/null


### PR DESCRIPTION
Current formatter version does not work with jdk16+, so requires an update