### PR TITLE
handle private orbs and multiple positional arguments

### DIFF
--- a/ls_pre_commit_hooks/circleci-config-validate.sh
+++ b/ls_pre_commit_hooks/circleci-config-validate.sh
@@ -57,7 +57,7 @@ do
     cmdArgs+=('-o' "${_ORG_SLUG}")
   fi
 
-  if ! eMSG=$(circleci "${cmdArgs[@]}"); then
+  if ! eMSG=$(circleci "${cmdArgs[@]}" 2>&1); then
     if [[ ${eMSG} =~ "Cannot find" ]] || [[ ${eMSG} =~ "Permission denied" ]]; then
       echo "This config probably uses private orbs, please run 'circleci setup' and provide your token."
     fi

--- a/ls_pre_commit_hooks/circleci-config-validate.sh
+++ b/ls_pre_commit_hooks/circleci-config-validate.sh
@@ -51,7 +51,7 @@ fi
 
 for path in "${positional_args[@]}"
 do
-  if ! eMSG=$(circleci --skip-update-check config validate -c "${path}" --org-slug ${_ORG_SLUG}); then
+  if ! eMSG=$(circleci --skip-update-check config validate -c "${path}" --org-slug "${_ORG_SLUG}"); then
     if [[ ${eMSG} =~ "Cannot find" ]] || [[ ${eMSG} =~ "Permission denied" ]]; then
       echo "This config probably uses private orbs, please run 'circleci setup' and provide your token."
     fi

--- a/ls_pre_commit_hooks/circleci-config-validate.sh
+++ b/ls_pre_commit_hooks/circleci-config-validate.sh
@@ -9,7 +9,7 @@ _ORG_SLUG=""
 function usage {
     echo "usage: [paths] [-h] [-o organization]"
     echo "  -h      display help"
-    echo "  -o      circleci organization (optional)"
+    echo "  -o      organization slug (for example: github/example-org), used when a config depends on private orbs"
     exit 1
 }
 
@@ -51,7 +51,13 @@ fi
 
 for path in "${positional_args[@]}"
 do
-  if ! eMSG=$(circleci --skip-update-check config validate -c "${path}" --org-slug "${_ORG_SLUG}"); then
+
+  cmdArgs=('--skip-update-check' 'config' 'validate' '-c' "${path}")
+  if [ -n "${_ORG_SLUG}" ]; then
+    cmdArgs+=('-o' "${_ORG_SLUG}")
+  fi
+
+  if ! eMSG=$(circleci "${cmdArgs[@]}"); then
     if [[ ${eMSG} =~ "Cannot find" ]] || [[ ${eMSG} =~ "Permission denied" ]]; then
       echo "This config probably uses private orbs, please run 'circleci setup' and provide your token."
     fi
@@ -59,4 +65,5 @@ do
     echo "${eMSG}"
     exit 1
   fi
+
 done

--- a/ls_pre_commit_hooks/circleci-config-validate.sh
+++ b/ls_pre_commit_hooks/circleci-config-validate.sh
@@ -4,13 +4,12 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-_ORG="github/lightspeed-hospitality"
-
+_ORG_SLUG_FLAG=""
 
 function usage {
     echo "usage: [paths] [-h] [-o organization]"
     echo "  -h      display help"
-    echo "  -o      circleci organization (default: ${_ORG})"
+    echo "  -o      circleci organization (optional)"
     exit 1
 }
 
@@ -22,7 +21,7 @@ do
         case $option
         in
             h) usage;;
-            o) _ORG_SLUG="--org-slug $OPTARG";;
+            o) _ORG_SLUG_FLAG="--org-slug $OPTARG";;
         esac
     else
         positional_args+=("${!OPTIND}")
@@ -52,7 +51,7 @@ fi
 
 for path in "${positional_args[@]}"
 do
-  if ! eMSG=$(circleci --skip-update-check config validate -c "${path}" "${_ORG_SLUG}"); then
+  if ! eMSG=$(circleci --skip-update-check config validate -c "${path}" "${_ORG_SLUG_FLAG}"); then
     if [[ ${eMSG} =~ "Cannot find" ]] || [[ ${eMSG} =~ "Permission denied" ]]; then
       echo "This config probably uses private orbs, please run 'circleci setup' and provide your token."
     fi

--- a/ls_pre_commit_hooks/circleci-config-validate.sh
+++ b/ls_pre_commit_hooks/circleci-config-validate.sh
@@ -8,7 +8,7 @@ _ORG="github/lightspeed-hospitality"
 
 
 function usage {
-    echo "usage: [-h] [-o organization]"
+    echo "usage: [paths] [-h] [-o organization]"
     echo "  -h      display help"
     echo "  -o      circleci organization (default: ${_ORG})"
     exit 1
@@ -52,7 +52,7 @@ fi
 
 for path in "${positional_args[@]}"
 do
-  if ! eMSG=$(circleci --skip-update-check config validate --org-slug "${_ORG}" -c "${path}}"); then
+  if ! eMSG=$(circleci --skip-update-check config validate --org-slug "${_ORG}" -c "${path}"); then
     if [[ ${eMSG} =~ "Cannot find" ]] || [[ ${eMSG} =~ "Permission denied" ]]; then
       echo "This config probably uses private orbs, please run 'circleci setup' and provide your token."
     fi

--- a/ls_pre_commit_hooks/circleci-config-validate.sh
+++ b/ls_pre_commit_hooks/circleci-config-validate.sh
@@ -5,8 +5,13 @@ set -o pipefail
 set -o nounset
 
 _PATH=$1
+_ORG=$2
 if [ -z "${_PATH}" ]; then
   _PATH=.circleci/config.yml
+fi
+
+if [ -z "${_ORG}" ]; then
+  _ORG=github/lightspeed-hospitality
 fi
 
 DEBUG=${DEBUG:=0}
@@ -28,7 +33,7 @@ if ! command -v circleci &>/dev/null; then
   exit 1
 fi
 
-if ! eMSG=$(circleci --skip-update-check config validate -c "${_PATH}"); then
+if ! eMSG=$(circleci --skip-update-check config validate --org-slug "${_ORG}" -c "${_PATH}"); then
   echo "CircleCI Configuration Failed Validation."
   echo $eMSG
   exit 1

--- a/ls_pre_commit_hooks/circleci-config-validate.sh
+++ b/ls_pre_commit_hooks/circleci-config-validate.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-_ORG_SLUG_FLAG=""
+_ORG_SLUG=""
 
 function usage {
     echo "usage: [paths] [-h] [-o organization]"
@@ -21,7 +21,7 @@ do
         case $option
         in
             h) usage;;
-            o) _ORG_SLUG_FLAG="--org-slug $OPTARG";;
+            o) _ORG_SLUG="${OPTARG}";;
         esac
     else
         positional_args+=("${!OPTIND}")
@@ -51,7 +51,7 @@ fi
 
 for path in "${positional_args[@]}"
 do
-  if ! eMSG=$(circleci --skip-update-check config validate -c "${path}" "${_ORG_SLUG_FLAG}"); then
+  if ! eMSG=$(circleci --skip-update-check config validate -c "${path}" --org-slug ${_ORG_SLUG}); then
     if [[ ${eMSG} =~ "Cannot find" ]] || [[ ${eMSG} =~ "Permission denied" ]]; then
       echo "This config probably uses private orbs, please run 'circleci setup' and provide your token."
     fi

--- a/ls_pre_commit_hooks/circleci-config-validate.sh
+++ b/ls_pre_commit_hooks/circleci-config-validate.sh
@@ -22,7 +22,7 @@ do
         case $option
         in
             h) usage;;
-            o) _ORG="$OPTARG";;
+            o) _ORG_SLUG="--org-slug $OPTARG";;
         esac
     else
         positional_args+=("${!OPTIND}")
@@ -52,7 +52,7 @@ fi
 
 for path in "${positional_args[@]}"
 do
-  if ! eMSG=$(circleci --skip-update-check config validate --org-slug "${_ORG}" -c "${path}"); then
+  if ! eMSG=$(circleci --skip-update-check config validate -c "${path}" "${_ORG_SLUG}"); then
     if [[ ${eMSG} =~ "Cannot find" ]] || [[ ${eMSG} =~ "Permission denied" ]]; then
       echo "This config probably uses private orbs, please run 'circleci setup' and provide your token."
     fi

--- a/ls_pre_commit_hooks/circleci-config-validate.sh
+++ b/ls_pre_commit_hooks/circleci-config-validate.sh
@@ -34,7 +34,10 @@ if ! command -v circleci &>/dev/null; then
 fi
 
 if ! eMSG=$(circleci --skip-update-check config validate --org-slug "${_ORG}" -c "${_PATH}"); then
+  if [[ ${eMSG} =~ "Cannot find" ]] || [[ ${eMSG} =~ "Permission denied" ]]; then
+    echo "This config probably uses private orbs, please run 'circleci setup' and provide your token."
+  fi
   echo "CircleCI Configuration Failed Validation."
-  echo $eMSG
+  echo ${eMSG}
   exit 1
 fi

--- a/ls_pre_commit_hooks/circleci-config-validate.sh
+++ b/ls_pre_commit_hooks/circleci-config-validate.sh
@@ -38,6 +38,6 @@ if ! eMSG=$(circleci --skip-update-check config validate --org-slug "${_ORG}" -c
     echo "This config probably uses private orbs, please run 'circleci setup' and provide your token."
   fi
   echo "CircleCI Configuration Failed Validation."
-  echo ${eMSG}
+  echo "${eMSG}"
   exit 1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ls-pre-commit-hooks"
-version = "0.7.9"
+version = "0.7.18"
 description = "A collection of useful pre-commit hooks used in Lightspeed Hospitality"
 authors = ["Your Name <you@example.com>"]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ls-pre-commit-hooks"
-version = "0.7.8"
+version = "0.7.9"
 description = "A collection of useful pre-commit hooks used in Lightspeed Hospitality"
 authors = ["Your Name <you@example.com>"]
 include = [


### PR DESCRIPTION
The script now handles multiple positional arguments and an `-o` flag too, examples:

```
bash circleci-config-validate.sh .circleci/config.yml -o github/lightspeed-hospitality
bash circleci-config-validate.sh .circleci/config.yml .circleci/config2.yml -o github/lightspeed-hospitality
```

Order doesn't matter:
```
bash circleci-config-validate.sh -o github/lightspeed-hospitality .circleci/config.yml .circleci/config2.yml 
```

`-o` flag is optional too:
```
bash circleci-config-validate.sh .circleci/config.yml .circleci/config2.yml 
```

Example of pre-commit config that uses private orbs:

```
    hooks:
      - id: circleci-config-validate
        args: ["-o", "github/lightspeed-hospitality"]
```