### PR TITLE
add random suffix to openapi linter container to fix conflict issues

### DIFF
--- a/ls_pre_commit_hooks/openapi-linter.sh
+++ b/ls_pre_commit_hooks/openapi-linter.sh
@@ -17,7 +17,8 @@ run_circle_ci() {
   # See here https://circleci.com/docs/building-docker-images/#mounting-folders for details.
   linter="$1"
   docker_image="$2"
-  container="${linter}-linter-volume"
+  random_suffix=$(uuidgen | tr -d '-')
+  container="${linter}-linter-volume-${random_suffix}"
 
   shift 2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ls-pre-commit-hooks"
-version = "0.7.22"
+version = "0.7.26"
 description = "A collection of useful pre-commit hooks used in Lightspeed Hospitality"
 authors = ["Your Name <you@example.com>"]
 include = [


### PR DESCRIPTION
Fixing conflicts when we run it multiple times, example: https://app.circleci.com/pipelines/github/lightspeed-hospitality/orli/5077/workflows/9f309c7f-840c-4a29-89dd-16fcc86b0464/jobs/69335?invite=true#step-112-154