### PR TITLE
Update poetry lock file

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -44,6 +44,21 @@ tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "binaryornot"
+version = "0.4.4"
+description = "Ultra-lightweight pure Python package to check if a file is binary or text."
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "binaryornot-0.4.4-py2.py3-none-any.whl", hash = "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4"},
+    {file = "binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"},
+]
+
+[package.dependencies]
+chardet = ">=3.0.2"
+
+[[package]]
 name = "black"
 version = "22.12.0"
 description = "The uncompromising code formatter."
@@ -197,6 +212,18 @@ files = [
 
 [package.dependencies]
 pycparser = "*"
+
+[[package]]
+name = "chardet"
+version = "5.1.0"
+description = "Universal encoding detector for Python 3"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "chardet-5.1.0-py3-none-any.whl", hash = "sha256:362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9"},
+    {file = "chardet-5.1.0.tar.gz", hash = "sha256:0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5"},
+]
 
 [[package]]
 name = "charset-normalizer"
@@ -355,7 +382,7 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "detect-secrets"
-version = "0.13.1+ibm.50.dss"
+version = "0.13.1+ibm.61.dss"
 description = "Tool for detecting secrets in the codebase"
 category = "main"
 optional = false
@@ -364,11 +391,13 @@ files = []
 develop = false
 
 [package.dependencies]
+binaryornot = "*"
 boxsdk = {version = "*", extras = ["jwt"]}
 packaging = "*"
 pyyaml = "*"
 requests = "*"
 tabulate = "*"
+urllib3 = "<2.0.0"
 
 [package.extras]
 db2 = ["ibm_db"]


### PR DESCRIPTION
I had to update the lock file again because it seems the default behaviour of `poetry lock` has changed.

I had to do `poetry update` then `poetry lock` to actually get an updated lock file.

Follow up to #61 