### PR TITLE
Add hadolint hook without docker

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -371,3 +371,11 @@
   language: docker_image
   types: ["dockerfile"]
   entry: ghcr.io/hadolint/hadolint:v2.12.0 hadolint
+# Based on https://github.com/hadolint/hadolint/blob/024fd640378acd5d8218f77ec2c744826cdda5ce/.pre-commit-hooks.yaml
+# But with a script that downloads it and runs the binary
+- id: hadolint-check
+  name: Lint Dockerfiles
+  description: Downloads and runs hadolint binary to lint Dockerfiles
+  language: script
+  types: ["dockerfile"]
+  entry: ls_pre_commit_hooks/hadolint-check.sh

--- a/ls_pre_commit_hooks/hadolint-check.sh
+++ b/ls_pre_commit_hooks/hadolint-check.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -o pipefail
+
+HADOLINT_VERSION=v2.12.0
+
+mkdir -p ".cache/hadolint-${HADOLINT_VERSION}"
+pushd ".cache/hadolint-${HADOLINT_VERSION}" > /dev/null
+
+if echo "${OSTYPE}" | grep -q darwin ; then
+  OS="Darwin"
+  ARCH="x86_64"  # There's no arm64 build as of 2023-07-07
+else
+  OS="Linux"
+  MACHINE_TYPE="$(uname -m)"
+  case "$MACHINE_TYPE" in
+      amd64 | x86_64 | x64)
+          ARCH="x86_64"
+          ;;
+      aarch64 | arm64)
+          ARCH="arm64"
+          ;;
+      *)
+          echo "Unknown machine type: $MACHINE_TYPE"
+          exit 1
+          ;;
+  esac
+fi
+
+URL="https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-${OS}-${ARCH}"
+
+FILE_NAME="hadolint-${OS}-${ARCH}"
+if [ ! -f "${FILE_NAME}" ] ; then
+  curl -sSL -o "${FILE_NAME}" "$URL"
+  chmod 755 "${FILE_NAME}"
+fi
+if [ ! -f "${FILE_NAME}.sha256" ] ; then
+  curl -sSL -o "${FILE_NAME}.sha256" "$URL.sha256"
+fi
+
+sha256sum -c "${FILE_NAME}.sha256"
+
+popd > /dev/null
+echo "Using hadolint version ${HADOLINT_VERSION}"
+
+exec ".cache/hadolint-${HADOLINT_VERSION}/${FILE_NAME}" "$@"


### PR DESCRIPTION
Add an alternative to the `hadolint-docker` hook with a version that downloads a binary and runs it outside of Docker, so that it plays nicely with Circle CI's docker shenanigans with volumes.

We can also remove that `hadolint-docker` hook.

We can also contribute this hook to the upstream project.