### PR TITLE
Allow passing parameters to the pytest hook

### DIFF
--- a/ls_pre_commit_hooks/poetry-pytest.sh
+++ b/ls_pre_commit_hooks/poetry-pytest.sh
@@ -19,4 +19,4 @@ fi
 
 echo "Running pytest in $PWD"
 poetry install --no-ansi --no-interaction -v
-poetry run --no-ansi --no-interaction -- pytest -vv
+poetry run --no-ansi --no-interaction -- pytest -vv "$@"


### PR DESCRIPTION
This would make `args: [tests/unit_tests]` work in the `.pre-commit-config.yaml` file.
