### PR TITLE
Set default org as lightspeed-hospitality

### DIFF
--- a/ls_pre_commit_hooks/circleci-config-validate.sh
+++ b/ls_pre_commit_hooks/circleci-config-validate.sh
@@ -4,12 +4,12 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-_ORG_SLUG=""
+_ORG_SLUG="github/lightspeed-hospitality"
 
 function usage {
     echo "usage: [paths] [-h] [-o organization]"
     echo "  -h      display help"
-    echo "  -o      organization slug (for example: github/example-org), used when a config depends on private orbs"
+    echo "  -o      organization slug (default: github/lightspeed-hospitality), used when a config depends on private orbs"
     exit 1
 }
 


### PR DESCRIPTION
This is the only option that makes sense for us using that pre-commit thing anyway, why make it explicit?
