### PR TITLE
NOJIRA: Fix hadolint download

### DIFF
--- a/ls_pre_commit_hooks/hadolint-check.sh
+++ b/ls_pre_commit_hooks/hadolint-check.sh
@@ -47,9 +47,10 @@ else
 
     curl -sSL -O "$URL.sha256"
     sha256sum -c "${DOWNLOADED_FILE_NAME}.sha256"
+
+    mv "${DOWNLOADED_FILE_NAME}" "${HADOLINT_FILE_NAME}"
   fi
 
-  mv "${DOWNLOADED_FILE_NAME}" "${HADOLINT_FILE_NAME}"
   CMD=".cache/hadolint-${HADOLINT_VERSION}/${HADOLINT_FILE_NAME}"
   popd > /dev/null
 fi

--- a/ls_pre_commit_hooks/hadolint-check.sh
+++ b/ls_pre_commit_hooks/hadolint-check.sh
@@ -33,20 +33,24 @@ if [[ $OS == "Darwin" ]]; then
   CMD="hadolint"
 else
   HADOLINT_VERSION="v2.13.1"
+  HADOLINT_FILE_NAME="hadolint"
   URL="https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-${OS}-${ARCH}"
-  
+
   mkdir -p ".cache/hadolint-${HADOLINT_VERSION}"
   pushd ".cache/hadolint-${HADOLINT_VERSION}" > /dev/null
 
-  echo "Fetching hadolint from ${URL}"
-  # Getting a real file name (avoiding possible file name changes, if that happens, the sha256 check will fail)
-  FILE_NAME=$(curl -sSLOJ -w '%{filename_effective}' "$URL")
-  chmod 755 "${FILE_NAME}"
+  if [ ! -f "${HADOLINT_FILE_NAME}" ] ; then
+    echo "Fetching hadolint from ${URL}"
+    # Getting a real file name (avoiding possible file name changes, if that happens, the sha256 check will fail)
+    DOWNLOADED_FILE_NAME=$(curl -sSLJ -O -w '%{filename_effective}' "$URL")
+    chmod 755 "${DOWNLOADED_FILE_NAME}"
+  
+    curl -sSL -O "$URL.sha256"
+    sha256sum -c "${DOWNLOADED_FILE_NAME}.sha256"
+  fi
 
-  curl -sSL -O "$URL.sha256"
-  sha256sum -c "${FILE_NAME}.sha256"
-
-  CMD=".cache/hadolint-${HADOLINT_VERSION}/${FILE_NAME}"
+  mv "${DOWNLOADED_FILE_NAME}" "${HADOLINT_FILE_NAME}"
+  CMD=".cache/hadolint-${HADOLINT_VERSION}/${HADOLINT_FILE_NAME}"
   popd > /dev/null
 fi
 

--- a/ls_pre_commit_hooks/hadolint-check.sh
+++ b/ls_pre_commit_hooks/hadolint-check.sh
@@ -44,7 +44,7 @@ else
     # Getting a real file name (avoiding possible file name changes, if that happens, the sha256 check will fail)
     DOWNLOADED_FILE_NAME=$(curl -sSLJ -O -w '%{filename_effective}' "$URL")
     chmod 755 "${DOWNLOADED_FILE_NAME}"
-  
+
     curl -sSL -O "$URL.sha256"
     sha256sum -c "${DOWNLOADED_FILE_NAME}.sha256"
   fi

--- a/ls_pre_commit_hooks/hadolint-check.sh
+++ b/ls_pre_commit_hooks/hadolint-check.sh
@@ -34,22 +34,16 @@ if [[ $OS == "Darwin" ]]; then
 else
   HADOLINT_VERSION="v2.13.1"
   URL="https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-${OS}-${ARCH}"
-  # Getting a real file name (avoiding possible file name changes, if that happens, the sha256 check will fail)
-  FILE_NAME=$(curl -sIL $URL | grep -i content-disposition | grep filename= | sed 's/.*filename=\(.*\)/\1/')
-
+  
   mkdir -p ".cache/hadolint-${HADOLINT_VERSION}"
   pushd ".cache/hadolint-${HADOLINT_VERSION}" > /dev/null
 
-  if [ ! -f "${FILE_NAME}" ] ; then
-    echo "Fetching hadolint from ${URL}"
-    curl -sSL -O "$URL"
-    chmod 755 "${FILE_NAME}"
-  fi
+  echo "Fetching hadolint from ${URL}"
+  # Getting a real file name (avoiding possible file name changes, if that happens, the sha256 check will fail)
+  FILE_NAME=$(curl -sSLOJ -w '%{filename_effective}' "$URL")
+  chmod 755 "${FILE_NAME}"
 
-  if [ ! -f "${FILE_NAME}.sha256" ] ; then
-    curl -sSL -O "$URL.sha256"
-  fi
-
+  curl -sSL -O "$URL.sha256"
   sha256sum -c "${FILE_NAME}.sha256"
 
   CMD=".cache/hadolint-${HADOLINT_VERSION}/${FILE_NAME}"

--- a/ls_pre_commit_hooks/hadolint-check.sh
+++ b/ls_pre_commit_hooks/hadolint-check.sh
@@ -3,9 +3,9 @@
 set -eo pipefail
 
 if [[ "${OSTYPE}" == *"darwin"* ]] ; then
-  OS="darwin"
+  OS="Darwin"
 else
-  OS="linux"
+  OS="Linux"
   MACHINE_TYPE="$(uname -m)"
   case "$MACHINE_TYPE" in
       amd64 | x86_64 | x64)
@@ -21,7 +21,7 @@ else
   esac
 fi
 
-if [[ $OS == "darwin" ]]; then
+if [[ $OS == "Darwin" ]]; then
   if ! command -v hadolint &>/dev/null; then
     if command -v brew &>/dev/null; then
       brew install --quiet hadolint
@@ -33,20 +33,21 @@ if [[ $OS == "darwin" ]]; then
   CMD="hadolint"
 else
   HADOLINT_VERSION="v2.13.1"
-  FILE_NAME="hadolint-${OS}-${ARCH}"
   URL="https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-${OS}-${ARCH}"
+  # Getting a real file name (avoiding possible file name changes, if that happens, the sha256 check will fail)
+  FILE_NAME=$(curl -sIL $URL | grep -i content-disposition | grep filename= | sed 's/.*filename=\(.*\)/\1/')
 
   mkdir -p ".cache/hadolint-${HADOLINT_VERSION}"
   pushd ".cache/hadolint-${HADOLINT_VERSION}" > /dev/null
 
   if [ ! -f "${FILE_NAME}" ] ; then
     echo "Fetching hadolint from ${URL}"
-    curl -sSL -o "${FILE_NAME}" "$URL"
+    curl -sSL -O "$URL"
     chmod 755 "${FILE_NAME}"
   fi
 
   if [ ! -f "${FILE_NAME}.sha256" ] ; then
-    curl -sSL -o "${FILE_NAME}.sha256" "$URL.sha256"
+    curl -sSL -O "$URL.sha256"
   fi
 
   sha256sum -c "${FILE_NAME}.sha256"

--- a/ls_pre_commit_hooks/hadolint-check.sh
+++ b/ls_pre_commit_hooks/hadolint-check.sh
@@ -3,9 +3,9 @@
 set -eo pipefail
 
 if [[ "${OSTYPE}" == *"darwin"* ]] ; then
-  OS="Darwin"
+  OS="darwin"
 else
-  OS="Linux"
+  OS="linux"
   MACHINE_TYPE="$(uname -m)"
   case "$MACHINE_TYPE" in
       amd64 | x86_64 | x64)
@@ -21,7 +21,7 @@ else
   esac
 fi
 
-if [[ $OS == "Darwin" ]]; then
+if [[ $OS == "darwin" ]]; then
   if ! command -v hadolint &>/dev/null; then
     if command -v brew &>/dev/null; then
       brew install --quiet hadolint


### PR DESCRIPTION
got a fun issue:
1. hadolint changed an artifact name: `Linux` became `linux`
2. becase we used a static file name the [sha256 check failed](https://app.circleci.com/pipelines/github/lightspeed-hospitality/auth-server/2213/workflows/638118ad-623a-40b1-b570-c95b43a9e196/jobs/18655) (the sha256 file references a file by name)
3. fixing by getting the real file name from the response headers