### PR TITLE
LSH-28555 Automate PRs for pre-commit-hook releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,4 +96,3 @@ workflows:
             branches:
               only:
                 - main
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
             UV_PATH=$(command -v uv 2>/dev/null || echo "${HOME}/.local/bin/uv")
             $UV_PATH venv ~/venv
             source ~/venv/bin/activate
+            $UV_PATH pip install setuptools wheel
             $UV_PATH pip install --config-file ~/.config/uv/config.toml --no-build-isolation-package pyyaml repo-tools
       - run:
           name: Get latest release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,13 @@ jobs:
       - lsk-python/get-codeartifact-token
       - lsk-python/add-codeartifact-uv
       - run:
+          name: Set SSH for GitHub
+          command: |
+            mkdir -p ~/.ssh
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+            ssh-add ~/.ssh/id_rsa_*
+            git config --global url."git@github.com:".insteadOf "https://github.com/"
+      - run:
           name: Create uv config file
           command: |
             mkdir -p ~/.config/uv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             $UV_PATH venv venv
             source venv/bin/activate
             $UV_PATH pip install setuptools wheel
-            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools==1.0.6.dev1091" --prerelease=allow
+            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools==1.0.6"
       - run:
           name: Get latest release
           command: |
@@ -84,10 +84,11 @@ workflows:
     jobs:
       - create-prs:
           context: global
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
+          filters:
+            branches:
+              only:
+                - main
+
   auto-pr-test:
     jobs:
       - create-prs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             $UV_PATH venv venv
             source venv/bin/activate
             $UV_PATH pip install setuptools wheel
-            $UV_PATH pip install --config-file ~/.config/uv/config.toml --no-build-isolation-package pyyaml repo-tools
+            $UV_PATH --config-file ~/.config/uv/config.toml pip install --no-build-isolation-package pyyaml repo-tools
       - run:
           name: Get latest release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,3 +77,7 @@ workflows:
           #   branches:
           #     only:
           #       - main
+  auto-pr-test:
+    jobs:
+      - create-prs:
+          context: global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             --apply-labels "⚠️ E2E Not Required" \
             --file-path ".pre-commit-config.yaml" \
             --auto-replace-with "$LATEST_RELEASE" \
-            --regex "(?<=^(\s*-\s*repo:\s*https://github\.com/lightspeed-hospitality/pre-commit-hooks\.git\n\s*rev:\s*))[^\n\s]+" \
+            --regex "^(?P<prefix>\s*-\s*repo:\s*https://github\.com/lightspeed-hospitality/pre-commit-hooks\.git\n\s*rev:\s*)[^\n\s]+(?=\n)" \
             --run-commands "pre-commit install" \
             --run-commands "pre-commit run" \
             --keep_repos false \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             $UV_PATH venv venv
             source venv/bin/activate
             $UV_PATH pip install setuptools wheel
-            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools==1.0.6.dev1063" --prerelease=allow
+            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools==1.0.6.dev1091" --prerelease=allow
       - run:
           name: Get latest release
           command: |
@@ -48,14 +48,11 @@ jobs:
             fi
             echo "Latest release found: $LATEST_RELEASE"
       - run:
-          name: Setup git credentials
-          command: |
-            echo "export GIT_USER=$GITHUB_USER" >> $BASH_ENV
-      - run:
           name: Create PR for new release
           command: |
             source venv/bin/activate
             export BRANCH_NAME="bump-pre-commit-hooks-to-$LATEST_RELEASE"
+            export GITHUB_EMAIL="sre-github-hospitality-user@lightspeedhq.com"
             rt config gh setup --no-use-keyring
             rt gh multi-edit \
             --branch "$BRANCH_NAME" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: |
             source venv/bin/activate
             export BRANCH_NAME="bump-pre-commit-hooks-to-$LATEST_RELEASE"
-            python3 -m rt gh multi-edit \
+            rt gh multi-edit \
             --branch "$BRANCH_NAME" \
             --commit-message "NOJIRA Bump pre-commit hooks" \
             --org "lightspeed-hospitality" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: Setup git credentials
           command: |
-            git config --global user.name $GITHUB_USER
+            echo "export GIT_USER=$GITHUB_USER" >> $BASH_ENV
       - run:
           name: Create PR for new release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,12 +47,13 @@ jobs:
             --branch "$BRANCH_NAME" \
             --commit-message "NOJIRA Bump pre-commit hooks" \
             --org "lightspeed-hospitality" \
-            --pr-description "A new version of pre-commit hooks is available." \
+            --pr-description "A new version of pre-commit hooks is available. Please take care of testing and merging this PR yourselves." \
             --apply-labels "⚠️ E2E Not Required" \
             --file-path ".pre-commit-config.yaml" \
             --auto-replace-with "\g<prefix>$LATEST_RELEASE" \
             --regex "^(?P<prefix>\s*-\s*repo:\s*https://github\.com/lightspeed-hospitality/pre-commit-hooks\.git\n\s*rev:\s*)[^\n\s]+(?=\n)" \
             --yes \
+            --dry-run \
             "https://github.com/lightspeed-hospitality/pre-commit-hooks.git"
 
 workflows:
@@ -72,7 +73,7 @@ workflows:
     jobs:
       - create-prs:
           context: global
-          filters:
-            branches:
-              only:
-                - main
+          # filters:
+          #   branches:
+          #     only:
+          #       - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             $UV_PATH venv venv
             source venv/bin/activate
             $UV_PATH pip install setuptools wheel
-            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools==1.0.6.dev1058" --prerelease=allow
+            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools==1.0.6.dev1063" --prerelease=allow
       - run:
           name: Get latest release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,13 +50,12 @@ jobs:
             --pr-description "A new version of pre-commit hooks is available." \
             --apply-labels "⚠️ E2E Not Required" \
             --file-path ".pre-commit-config.yaml" \
-            --auto-replace-with "$LATEST_RELEASE" \
+            --auto-replace-with "\g<prefix>$LATEST_RELEASE" \
             --regex "^(?P<prefix>\s*-\s*repo:\s*https://github\.com/lightspeed-hospitality/pre-commit-hooks\.git\n\s*rev:\s*)[^\n\s]+(?=\n)" \
             --run-commands "pre-commit install" \
             --run-commands "pre-commit run" \
-            --keep_repos false \
             --yes \
-            "repo: https://github.com/lightspeed-hospitality/pre-commit-hooks.git"
+            "https://github.com/lightspeed-hospitality/pre-commit-hooks.git"
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,6 @@ jobs:
       - lsk-python/get-codeartifact-token
       - lsk-python/add-codeartifact-uv
       - run:
-          name: Set SSH for GitHub
-          command: |
-            mkdir -p ~/.ssh
-            ssh-keyscan github.com >> ~/.ssh/known_hosts
-            ssh-add ~/.ssh/id_rsa
-            git config --global url."git@github.com:".insteadOf "https://github.com/"
-      - run:
           name: Create uv config file
           command: |
             mkdir -p ~/.config/uv
@@ -40,7 +33,7 @@ jobs:
             $UV_PATH venv venv
             source venv/bin/activate
             $UV_PATH pip install setuptools wheel
-            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools>1.0.3" --prerelease=allow
+            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools==1.0.6.dev1051" --prerelease=allow
       - run:
           name: Get latest release
           command: |
@@ -71,6 +64,7 @@ jobs:
             --regex "^(?P<prefix>\s*-\s*repo:\s*https://github\.com/lightspeed-hospitality/pre-commit-hooks\.git\n\s*rev:\s*)[^\n\s]+(?=\n)" \
             --yes \
             --dry-run \
+            --auth-type https \
             "https://github.com/lightspeed-hospitality/pre-commit-hooks.git"
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@
 version: 2.1
 orbs:
   lsk-python: lsk/python@2.0
+  gh: circleci/github-cli@2.7.2
 
 jobs:
   create-prs:
@@ -10,6 +11,8 @@ jobs:
       tag: "3.13"
     steps:
       - checkout
+      - gh/install
+      - gh/setup
       - lsk-python/install-uv
       - get-codeartifact-token
       - add-codeartifact-uv
@@ -25,7 +28,26 @@ jobs:
           name: Install repo-tools
           command: |
             sudo uv pip install --system --config-file ~/.config/uv/config.toml repo-tools
-
+      - run:
+          name: Get latest release
+          command: |
+            gh release view --json tagName --jq .tagName > LATEST_RELEASE
+      - run:
+          name: Create PR for new release
+          command: |
+            export BRANCH_NAME="bump-pre-commit-hooks-to-$(cat LATEST_RELEASE)"
+            rt gh multi-edit \
+            --branch "$BRANCH_NAME" \
+            --commit-message "NOJIRA Bump pre-commit hooks" \
+            --pr-description "A new version of pre-commit hooks is available." \
+            --apply-labels "⚠️ E2E Not Required" \
+            --file-path ".pre-commit-config.yaml" \
+            --auto-replace-with "$(cat LATEST_RELEASE)" \
+            --regex "(?<=^(\s*-\s*repo:\s*https://github\.com/lightspeed-hospitality/pre-commit-hooks\.git\n\s*rev:\s*))[^\n\s]+" \
+            --run-commands "pre-commit install" \
+            --run-commands "pre-commit run" \
+            --yes \
+            "repo: https://github.com/lightspeed-hospitality/pre-commit-hooks.git"
 
 workflows:
   main:
@@ -33,16 +55,18 @@ workflows:
       - lsk-python/pre-commit:
           context: global
           executor-name: "python-3-9"
+  auto-pr:
+    triggers:
+      - schedule:
+          cron: "0 12 * * *" # every day at noon
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              only: /.*/
+              only:
+                - main
+    jobs:
       - create-prs:
-          requires:
-            - lsk-python/pre-commit
+          context: global
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              ignore: /.*/
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             $UV_PATH venv venv
             source venv/bin/activate
             $UV_PATH pip install setuptools wheel
-            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools==1.0.6.dev1055" --prerelease=allow
+            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools==1.0.6.dev1058" --prerelease=allow
       - run:
           name: Get latest release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,6 @@ jobs:
             --file-path ".pre-commit-config.yaml" \
             --auto-replace-with "\g<prefix>$LATEST_RELEASE" \
             --regex "^(?P<prefix>\s*-\s*repo:\s*https://github\.com/lightspeed-hospitality/pre-commit-hooks\.git\n\s*rev:\s*)[^\n\s]+(?=\n)" \
-            --run-commands "pre-commit install" \
-            --run-commands "pre-commit run" \
             --yes \
             "https://github.com/lightspeed-hospitality/pre-commit-hooks.git"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,6 @@ jobs:
       - lsk-python/get-codeartifact-token
       - lsk-python/add-codeartifact-uv
       - run:
-          name: Configure git for private repositories
-          command: |
-            git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-            git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:"
-      - run:
           name: Create uv config file
           command: |
             mkdir -p ~/.config/uv
@@ -38,7 +33,7 @@ jobs:
             $UV_PATH venv venv
             source venv/bin/activate
             $UV_PATH pip install setuptools wheel
-            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools==1.0.6.dev1051" --prerelease=allow
+            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools==1.0.6.dev1055" --prerelease=allow
       - run:
           name: Get latest release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,14 +26,11 @@ jobs:
             echo '[[index]]' >> ~/.config/uv/config.toml
             echo 'name = "pypi"' >> ~/.config/uv/config.toml
             echo 'url = "https://pypi.org/simple/"' >> ~/.config/uv/config.toml
-            # Workaround for pyyaml build isolation issue
-            echo '' >> ~/.config/uv/config.toml
-            echo 'no-build-isolation-package = ["pyyaml"]' >> ~/.config/uv/config.toml
       - run:
           name: Install repo-tools
           command: |
             UV_PATH=$(command -v uv 2>/dev/null || echo "${HOME}/.local/bin/uv")
-            $UV_PATH pip install --target "$(python3 -m site --user-site)" --config-file ~/.config/uv/config.toml repo-tools
+            $UV_PATH pip install --target "$(python3 -m site --user-site)" --config-file ~/.config/uv/config.toml --no-build-isolation-package pyyaml repo-tools
       - run:
           name: Get latest release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           name: Install repo-tools
           command: |
             UV_PATH=$(command -v uv 2>/dev/null || echo "${HOME}/.local/bin/uv")
-            $UV_PATH pip install --target "$(python3 -m site --user-site)" --config-file ~/.config/uv/config.toml --no-build-isolation-package pyyaml repo-tools
+            $UV_PATH pip install --config-file ~/.config/uv/config.toml --no-build-isolation-package pyyaml repo-tools
       - run:
           name: Get latest release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
             echo '[[index]]' >> ~/.config/uv/config.toml
             echo 'name = "pypi"' >> ~/.config/uv/config.toml
             echo 'url = "https://pypi.org/simple/"' >> ~/.config/uv/config.toml
+            # Workaround for pyyaml build isolation issue
             echo '' >> ~/.config/uv/config.toml
             echo 'no-build-isolation-package = ["pyyaml"]' >> ~/.config/uv/config.toml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 
 jobs:
   create-prs:
-    executor: lsk-python/python-3-13
+    executor: lsk-python/python-3-11
     steps:
       - checkout
       - gh/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
             --yes \
             --dry-run \
             --auth-type https \
-            "https://github.com/lightspeed-hospitality/pre-commit-hooks.git"
+            "exclude: '.*poetry.lock$'"
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,8 @@ jobs:
             echo '[[index]]' >> ~/.config/uv/config.toml
             echo 'name = "pypi"' >> ~/.config/uv/config.toml
             echo 'url = "https://pypi.org/simple/"' >> ~/.config/uv/config.toml
+            echo '' >> ~/.config/uv/config.toml
+            echo 'no-build-isolation-package = ["pyyaml"]' >> ~/.config/uv/config.toml
       - run:
           name: Install repo-tools
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,6 @@ jobs:
             --auto-replace-with "\g<prefix>$LATEST_RELEASE" \
             --regex "^(?P<prefix>\s*-\s*repo:\s*https://github\.com/lightspeed-hospitality/pre-commit-hooks\.git\n\s*rev:\s*)[^\n\s]+(?=\n)" \
             --yes \
-            --dry-run \
             --auth-type https \
             "exclude: '.*poetry.lock$'"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
             --regex "^(?P<prefix>\s*-\s*repo:\s*https://github\.com/lightspeed-hospitality/pre-commit-hooks\.git\n\s*rev:\s*)[^\n\s]+(?=\n)" \
             --yes \
             --auth-type https \
-            "exclude: '.*poetry.lock$'"
+            "https://github.com/lightspeed-hospitality/pre-commit-hooks.git"
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 
 jobs:
   create-prs:
-    executor: python/python-3-13
+    executor: lsk-python/python-3-13
     steps:
       - checkout
       - gh/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
           command: |
             source venv/bin/activate
             export BRANCH_NAME="bump-pre-commit-hooks-to-$LATEST_RELEASE"
+            rt config gh setup --no-use-keyring
             rt gh multi-edit \
             --branch "$BRANCH_NAME" \
             --commit-message "NOJIRA Bump pre-commit hooks" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             $UV_PATH venv venv
             source venv/bin/activate
             $UV_PATH pip install setuptools wheel
-            $UV_PATH --config-file ~/.config/uv/config.toml pip install --no-build-isolation-package pyyaml repo-tools
+            $UV_PATH --config-file ~/.config/uv/config.toml pip install -v --no-build-isolation-package pyyaml repo-tools
       - run:
           name: Get latest release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           command: |
             mkdir -p ~/.ssh
             ssh-keyscan github.com >> ~/.ssh/known_hosts
-            ssh-add ~/.ssh/id_rsa_*
+            ssh-add ~/.ssh/id_rsa
             git config --global url."git@github.com:".insteadOf "https://github.com/"
       - run:
           name: Create uv config file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Create PR for new release
           command: |
             export BRANCH_NAME="bump-pre-commit-hooks-to-$LATEST_RELEASE"
-            rt gh multi-edit \
+            python3 -m rt gh multi-edit \
             --branch "$BRANCH_NAME" \
             --commit-message "NOJIRA Bump pre-commit hooks" \
             --org "lightspeed-hospitality" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,8 @@ jobs:
       - run:
           name: Install repo-tools
           command: |
-            sudo uv pip install --system --config-file ~/.config/uv/config.toml repo-tools
+            UV_PATH=$(command -v uv 2>/dev/null || echo "${HOME}/.local/bin/uv")
+            $UV_PATH pip install --target "$(python3 -m site --user-site)" --config-file ~/.config/uv/config.toml repo-tools
       - run:
           name: Get latest release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,14 @@ workflows:
       - lsk-python/pre-commit:
           context: global
           executor-name: "python-3-9"
+      - create-prs:
+          context: global
+          requires:
+            - lsk-python/pre-commit
+          filters:
+            branches:
+              only:
+                - main
   auto-pr:
     triggers:
       - schedule:
@@ -89,7 +97,3 @@ workflows:
               only:
                 - main
 
-  auto-pr-test:
-    jobs:
-      - create-prs:
-          context: global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,7 @@ orbs:
 
 jobs:
   create-prs:
-    executor:
-      name: lsk-python/python-executor
-      tag: "3.13"
+    executor: python/python-3-13
     steps:
       - checkout
       - gh/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             $UV_PATH venv venv
             source venv/bin/activate
             $UV_PATH pip install setuptools wheel
-            $UV_PATH pip install -v --no-build-isolation-package pyyaml repo-tools
+            $UV_PATH pip install -v --no-build-isolation-package pyyaml --index-strategy unsafe-best-match "repo-tools>1.0.3" --prerelease=allow
       - run:
           name: Get latest release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,12 @@ jobs:
           name: Create uv config file
           command: |
             mkdir -p ~/.config/uv
-            echo '[[index]]' > ~/.config/uv/config.toml
+            echo '[[tool.uv.index]]' > ~/.config/uv/config.toml
             echo 'name = "lsk-pypi"' >> ~/.config/uv/config.toml
             echo 'url = "https://lsk-809245501444.d.codeartifact.us-east-1.amazonaws.com/pypi/lsk-pypi/simple/"' >> ~/.config/uv/config.toml
             echo 'default = true' >> ~/.config/uv/config.toml
             echo '' >> ~/.config/uv/config.toml
-            echo '[[index]]' >> ~/.config/uv/config.toml
+            echo '[[tool.uv.index]]' >> ~/.config/uv/config.toml
             echo 'name = "pypi"' >> ~/.config/uv/config.toml
             echo 'url = "https://pypi.org/simple/"' >> ~/.config/uv/config.toml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 
 jobs:
   create-prs:
-    executor: lsk-python/python-3-11
+    executor: lsk-python/python-3-10
     steps:
       - checkout
       - gh/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,12 @@ jobs:
           name: Create uv config file
           command: |
             mkdir -p ~/.config/uv
-            echo '[[tool.uv.index]]' > ~/.config/uv/uv.toml
+            echo '[[index]]' > ~/.config/uv/uv.toml
             echo 'name = "lsk-pypi"' >> ~/.config/uv/uv.toml
             echo 'url = "https://lsk-809245501444.d.codeartifact.us-east-1.amazonaws.com/pypi/lsk-pypi/simple/"' >> ~/.config/uv/uv.toml
             echo 'default = true' >> ~/.config/uv/uv.toml
             echo '' >> ~/.config/uv/uv.toml
-            echo '[[tool.uv.index]]' >> ~/.config/uv/uv.toml
+            echo '[[index]]' >> ~/.config/uv/uv.toml
             echo 'name = "pypi"' >> ~/.config/uv/uv.toml
             echo 'url = "https://pypi.org/simple/"' >> ~/.config/uv/uv.toml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
           name: Install repo-tools
           command: |
             UV_PATH=$(command -v uv 2>/dev/null || echo "${HOME}/.local/bin/uv")
-            $UV_PATH venv ~/venv
-            source ~/venv/bin/activate
+            $UV_PATH venv venv
+            source venv/bin/activate
             $UV_PATH pip install setuptools wheel
             $UV_PATH pip install --config-file ~/.config/uv/config.toml --no-build-isolation-package pyyaml repo-tools
       - run:
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: Create PR for new release
           command: |
-            source ~/venv/bin/activate
+            source venv/bin/activate
             export BRANCH_NAME="bump-pre-commit-hooks-to-$LATEST_RELEASE"
             python3 -m rt gh multi-edit \
             --branch "$BRANCH_NAME" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
             echo 'name = "lsk-pypi"' >> ~/.config/uv/config.toml
             echo 'url = "https://lsk-809245501444.d.codeartifact.us-east-1.amazonaws.com/pypi/lsk-pypi/simple/"' >> ~/.config/uv/config.toml
             echo 'default = true' >> ~/.config/uv/config.toml
+            echo '' >> ~/.config/uv/config.toml
+            echo '[[index]]' >> ~/.config/uv/config.toml
+            echo 'name = "pypi"' >> ~/.config/uv/config.toml
+            echo 'url = "https://pypi.org/simple/"' >> ~/.config/uv/config.toml
       - run:
           name: Install repo-tools
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,14 @@ jobs:
           name: Create uv config file
           command: |
             mkdir -p ~/.config/uv
-            echo '[[tool.uv.index]]' > ~/.config/uv/config.toml
-            echo 'name = "lsk-pypi"' >> ~/.config/uv/config.toml
-            echo 'url = "https://lsk-809245501444.d.codeartifact.us-east-1.amazonaws.com/pypi/lsk-pypi/simple/"' >> ~/.config/uv/config.toml
-            echo 'default = true' >> ~/.config/uv/config.toml
-            echo '' >> ~/.config/uv/config.toml
-            echo '[[tool.uv.index]]' >> ~/.config/uv/config.toml
-            echo 'name = "pypi"' >> ~/.config/uv/config.toml
-            echo 'url = "https://pypi.org/simple/"' >> ~/.config/uv/config.toml
+            echo '[[tool.uv.index]]' > ~/.config/uv/uv.toml
+            echo 'name = "lsk-pypi"' >> ~/.config/uv/uv.toml
+            echo 'url = "https://lsk-809245501444.d.codeartifact.us-east-1.amazonaws.com/pypi/lsk-pypi/simple/"' >> ~/.config/uv/uv.toml
+            echo 'default = true' >> ~/.config/uv/uv.toml
+            echo '' >> ~/.config/uv/uv.toml
+            echo '[[tool.uv.index]]' >> ~/.config/uv/uv.toml
+            echo 'name = "pypi"' >> ~/.config/uv/uv.toml
+            echo 'url = "https://pypi.org/simple/"' >> ~/.config/uv/uv.toml
       - run:
           name: Install repo-tools
           command: |
@@ -33,7 +33,7 @@ jobs:
             $UV_PATH venv venv
             source venv/bin/activate
             $UV_PATH pip install setuptools wheel
-            $UV_PATH --config-file ~/.config/uv/config.toml pip install -v --no-build-isolation-package pyyaml repo-tools
+            $UV_PATH pip install -v --no-build-isolation-package pyyaml repo-tools
       - run:
           name: Get latest release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ jobs:
       - gh/install
       - gh/setup
       - lsk-python/install-uv
-      - get-codeartifact-token
-      - add-codeartifact-uv
+      - lsk-python/get-codeartifact-token
+      - lsk-python/add-codeartifact-uv
       - run:
           name: Create uv config file
           command: |
@@ -47,6 +47,7 @@ jobs:
             --regex "(?<=^(\s*-\s*repo:\s*https://github\.com/lightspeed-hospitality/pre-commit-hooks\.git\n\s*rev:\s*))[^\n\s]+" \
             --run-commands "pre-commit install" \
             --run-commands "pre-commit run" \
+            --keep_repos false \
             --yes \
             "repo: https://github.com/lightspeed-hospitality/pre-commit-hooks.git"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,20 @@ jobs:
       - run:
           name: Get latest release
           command: |
-            gh release view --json tagName --jq .tagName > LATEST_RELEASE
+            LATEST_RELEASE=$(gh release view --json tagName --jq .tagName)
+            echo "export LATEST_RELEASE=$LATEST_RELEASE" >> $BASH_ENV
+      - run:
+          name: Check if release exists
+          command: |
+            if [ -z "$LATEST_RELEASE" ]; then
+              echo "No latest release found, exiting early"
+              exit 1
+            fi
+            echo "Latest release found: $LATEST_RELEASE"
       - run:
           name: Create PR for new release
           command: |
-            export BRANCH_NAME="bump-pre-commit-hooks-to-$(cat LATEST_RELEASE)"
+            export BRANCH_NAME="bump-pre-commit-hooks-to-$LATEST_RELEASE"
             rt gh multi-edit \
             --branch "$BRANCH_NAME" \
             --commit-message "NOJIRA Bump pre-commit hooks" \
@@ -41,7 +50,7 @@ jobs:
             --pr-description "A new version of pre-commit hooks is available." \
             --apply-labels "⚠️ E2E Not Required" \
             --file-path ".pre-commit-config.yaml" \
-            --auto-replace-with "$(cat LATEST_RELEASE)" \
+            --auto-replace-with "$LATEST_RELEASE" \
             --regex "(?<=^(\s*-\s*repo:\s*https://github\.com/lightspeed-hospitality/pre-commit-hooks\.git\n\s*rev:\s*))[^\n\s]+" \
             --run-commands "pre-commit install" \
             --run-commands "pre-commit run" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
             rt gh multi-edit \
             --branch "$BRANCH_NAME" \
             --commit-message "NOJIRA Bump pre-commit hooks" \
+            --org "lightspeed-hospitality" \
             --pr-description "A new version of pre-commit hooks is available." \
             --apply-labels "⚠️ E2E Not Required" \
             --file-path ".pre-commit-config.yaml" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,10 @@ jobs:
             fi
             echo "Latest release found: $LATEST_RELEASE"
       - run:
+          name: Setup git credentials
+          command: |
+            git config --global user.name $GITHUB_USER
+      - run:
           name: Create PR for new release
           command: |
             source venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,31 @@
 ---
 version: 2.1
 orbs:
-  lsk-python: lsk/python@1.4
+  lsk-python: lsk/python@2.0
+
+jobs:
+  create-prs:
+    executor:
+      name: lsk-python/python-executor
+      tag: "3.13"
+    steps:
+      - checkout
+      - lsk-python/install-uv
+      - get-codeartifact-token
+      - add-codeartifact-uv
+      - run:
+          name: Create uv config file
+          command: |
+            mkdir -p ~/.config/uv
+            echo '[[index]]' > ~/.config/uv/config.toml
+            echo 'name = "lsk-pypi"' >> ~/.config/uv/config.toml
+            echo 'url = "https://lsk-809245501444.d.codeartifact.us-east-1.amazonaws.com/pypi/lsk-pypi/simple/"' >> ~/.config/uv/config.toml
+            echo 'default = true' >> ~/.config/uv/config.toml
+      - run:
+          name: Install repo-tools
+          command: |
+            sudo uv pip install --system --config-file ~/.config/uv/config.toml repo-tools
+
 
 workflows:
   main:
@@ -9,3 +33,16 @@ workflows:
       - lsk-python/pre-commit:
           context: global
           executor-name: "python-3-9"
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /.*/
+      - create-prs:
+          requires:
+            - lsk-python/pre-commit
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,11 @@ jobs:
       - lsk-python/get-codeartifact-token
       - lsk-python/add-codeartifact-uv
       - run:
+          name: Configure git for private repositories
+          command: |
+            git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:"
+      - run:
           name: Create uv config file
           command: |
             mkdir -p ~/.config/uv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,9 @@ jobs:
           name: Install repo-tools
           command: |
             UV_PATH=$(command -v uv 2>/dev/null || echo "${HOME}/.local/bin/uv")
-            $UV_PATH pip install --target "$(python3 -m site --user-site)" --config-file ~/.config/uv/config.toml --no-build-isolation-package pyyaml repo-tools
+            $UV_PATH venv ~/venv
+            source ~/venv/bin/activate
+            $UV_PATH pip install --config-file ~/.config/uv/config.toml --no-build-isolation-package pyyaml repo-tools
       - run:
           name: Get latest release
           command: |
@@ -47,8 +49,8 @@ jobs:
       - run:
           name: Create PR for new release
           command: |
+            source ~/venv/bin/activate
             export BRANCH_NAME="bump-pre-commit-hooks-to-$LATEST_RELEASE"
-            export PYTHONPATH="$(python3 -m site --user-site):$PYTHONPATH"
             python3 -m rt gh multi-edit \
             --branch "$BRANCH_NAME" \
             --commit-message "NOJIRA Bump pre-commit hooks" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           name: Install repo-tools
           command: |
             UV_PATH=$(command -v uv 2>/dev/null || echo "${HOME}/.local/bin/uv")
-            $UV_PATH pip install --config-file ~/.config/uv/config.toml --no-build-isolation-package pyyaml repo-tools
+            $UV_PATH pip install --target "$(python3 -m site --user-site)" --config-file ~/.config/uv/config.toml --no-build-isolation-package pyyaml repo-tools
       - run:
           name: Get latest release
           command: |
@@ -48,6 +48,7 @@ jobs:
           name: Create PR for new release
           command: |
             export BRANCH_NAME="bump-pre-commit-hooks-to-$LATEST_RELEASE"
+            export PYTHONPATH="$(python3 -m site --user-site):$PYTHONPATH"
             python3 -m rt gh multi-edit \
             --branch "$BRANCH_NAME" \
             --commit-message "NOJIRA Bump pre-commit hooks" \


### PR DESCRIPTION
This PR adds a scheduled ci job that will check if all pre-commit hooks in the org are of the newest version set in this release.

TODO:
- [x] Fix pipeline issues
- [x] Needs to be tested with dry-run: Tested [here](https://app.circleci.com/pipelines/github/lightspeed-hospitality/pre-commit-hooks/467/workflows/55e76d35-9c8b-4863-9ba4-a188619b3da3/jobs/423)